### PR TITLE
handle 404 errors

### DIFF
--- a/vk_captcha/solver.py
+++ b/vk_captcha/solver.py
@@ -158,6 +158,8 @@ class VkCaptchaSolver:
                         if bytes_data is None:
                             raise ProxyError(
                                 "Can not download captcha - probably proxy error")
+                        if resp.status != 200:
+                            raise ProxyError(f"resp.status: {resp.status}")
                         break
                     except Exception:
                         if _ == 3:


### PR DESCRIPTION
при статусе 404 приходит ответ `{"error": {"error_code": 3,"error_msg": "Not found"}}`
Баг в том что `bytes_data` получает вместо изображения текст. 